### PR TITLE
Remove last build dependency on libdevmapper.h

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -12,7 +12,7 @@ Library               devmapper
   Pack:               true
   Path:               lib
   Modules:            S, Location, Striped, Target, Linux, Mock
-  CSources:           camldm_stubs.c, devmapper_stubs.c
+  CSources:           camldm_stubs.c
   CCLib:              -ldevmapper
   BuildDepends:       rpclib, rpclib.syntax, ctypes (>= 0.3.0), ctypes.foreign, sexplib, sexplib.syntax, stringext
 

--- a/lib/camldm_stubs.c
+++ b/lib/camldm_stubs.c
@@ -11,7 +11,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  */
-#include <libdevmapper.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>

--- a/lib/linux.ml
+++ b/lib/linux.ml
@@ -42,7 +42,27 @@ module Lowlevel = struct
   | DM_DEVICE_LIST_VERSIONS
   | DM_DEVICE_TARGET_MSG
   | DM_DEVICE_SET_GEOMETRY
-  external dm_kind_to_int: kind -> int = "dm_kind_to_int"
+  (* These must match libdevmapper.h: *)
+  let dm_kind_to_int = function
+  | DM_DEVICE_CREATE        -> 0
+  | DM_DEVICE_RELOAD        -> 1
+  | DM_DEVICE_REMOVE        -> 2
+  | DM_DEVICE_REMOVE_ALL    -> 3
+  | DM_DEVICE_SUSPEND       -> 4
+  | DM_DEVICE_RESUME        -> 5
+  | DM_DEVICE_INFO          -> 6
+  | DM_DEVICE_DEPS          -> 7
+  | DM_DEVICE_RENAME        -> 8
+  | DM_DEVICE_VERSION       -> 9
+  | DM_DEVICE_STATUS        -> 10
+  | DM_DEVICE_TABLE         -> 11
+  | DM_DEVICE_WAITEVENT     -> 12
+  | DM_DEVICE_LIST          -> 13
+  | DM_DEVICE_CLEAR         -> 14
+  | DM_DEVICE_MKNODES       -> 15
+  | DM_DEVICE_LIST_VERSIONS -> 16
+  | DM_DEVICE_TARGET_MSG    -> 17
+  | DM_DEVICE_SET_GEOMETRY  -> 18
 
   type dm_task = [ `Dm_task ] structure ptr
 


### PR DESCRIPTION
90% of the binding was using dlopen() so we're already dependent on the ABI rather than the API.
